### PR TITLE
🐛 날짜 불일치 버그 해결

### DIFF
--- a/src/app/blog/[...slug]/page.tsx
+++ b/src/app/blog/[...slug]/page.tsx
@@ -1,5 +1,5 @@
 import StaticChip from '@/component/ui/static/StaticChip'
-import { formatDate } from '@/lib/dateUtil'
+import { formatDateKr } from '@/lib/dateUtil'
 import { parsedMarkdowns } from '@/lib/markdownFileUtil'
 import React from 'react'
 
@@ -28,7 +28,7 @@ async function PostDetailPage({ params }: PostDetailPageProps) {
   const { slug } = await params
   const path = decodeURIComponent(slug.join("/"))
   const matchedMarkdown = parsedMarkdowns.find(md => md.path.includes(`${path}.mdx`))
-  const formattedDate = formatDate(new Date(matchedMarkdown?.frontmatter.date ?? ""))
+  const formattedDate = formatDateKr(new Date(matchedMarkdown?.frontmatter.date ?? ""))
 
   return (
     <article className='max-w-3xl mx-auto'>

--- a/src/component/about/AffiliationPeriodCard.tsx
+++ b/src/component/about/AffiliationPeriodCard.tsx
@@ -1,4 +1,4 @@
-import { formatDate } from '@/lib/dateUtil'
+import { formatDateKr } from '@/lib/dateUtil'
 import React from 'react'
 
 export type AffiliationPeriodProps = {
@@ -9,8 +9,8 @@ export type AffiliationPeriodProps = {
 }
 
 function AffiliationPeriodCard({ organization, description, startDate, endDate }: AffiliationPeriodProps) {
-  const formattedStartDate = `${formatDate(startDate).year} ${formatDate(startDate).month}`
-  const formattedEndDate = endDate instanceof Date ? `${formatDate(endDate).year} ${formatDate(endDate).month}` : endDate
+  const formattedStartDate = `${formatDateKr(startDate).year} ${formatDateKr(startDate).month}`
+  const formattedEndDate = endDate instanceof Date ? `${formatDateKr(endDate).year} ${formatDateKr(endDate).month}` : endDate
 
   return (
     <div className='md:mr-48'>

--- a/src/component/blog/PostItem.tsx
+++ b/src/component/blog/PostItem.tsx
@@ -1,4 +1,4 @@
-import { formatDate } from '@/lib/dateUtil'
+import { formatDateKr } from '@/lib/dateUtil'
 import Link from 'next/link'
 import React from 'react'
 
@@ -10,7 +10,7 @@ type PostItemProps = {
 }
 
 function PostItem({ title, subtitle, date, path }: PostItemProps) {
-  const formattedDate = formatDate(date)
+  const formattedDate = formatDateKr(date)
   
   return (
     <li className='relative p-4 group-hover:opacity-50 hover:opacity-100 hover:bg-system-gray-6 rounded-lg' style={{transition: "background-color 0.3s ease-in-out, opacity 0.3s ease-in-out"}}>

--- a/src/component/blog/PostList.tsx
+++ b/src/component/blog/PostList.tsx
@@ -11,7 +11,7 @@ function organizePostsByYear(posts: ParsedMarkdownType): { year: number; posts: 
   const postsByYear: { [key: number]: ParsedMarkdownType } = {}
 
   posts.forEach(post => {
-    const year = new Date(post.frontmatter.date).getFullYear()
+    const year = new Date(post.frontmatter.date.split("T")[0]).getFullYear()
     
     if (!postsByYear[year]) {
       postsByYear[year] = []

--- a/src/lib/dateUtil.ts
+++ b/src/lib/dateUtil.ts
@@ -1,11 +1,11 @@
-export const formatDate = (date: Date) => {
-  const year = String(date.getFullYear())
-  const month = String(date.getMonth() + 1)
-  const day = String(date.getDate())
+export const formatDateKr = (date: Date) => {
+  const year = date.toLocaleDateString("ko-KR", { year: "numeric", timeZone: "Asia/Seoul" })
+  const month = date.toLocaleDateString("ko-KR", { month: "numeric", timeZone: "Asia/Seoul" })
+  const day = date.toLocaleDateString("ko-KR", { day: "numeric", timeZone: "Asia/Seoul" })
 
   return {
-    year: `${year}년`,
-    month: `${month}월`,
-    day: `${day}일`
+    year,
+    month,
+    day
   }
 }


### PR DESCRIPTION
### AS-IS
- 배포 이후 포스트의 작성일자가 불일치하는 버그가 발견됨(작성일자 `19일` -> `18일`로 표시됨)
- 게시글의 작성일자는 `frontmatter.date`에 명시되어있으며, UTC+9가 명시되어있는 상황이었음(ex. `2025-03-19T00:00:00+09:00`)
  - 이를 기반으로 `Date`객체 생성시 UTC+0 타임존으로 변환되며 날짜가 앞당겨졌음
  - 로컬에서는 발생하지 않는 이슈였기에 발견이 늦어짐(이유: Date 객체 생성시 JavaScript 런타임 환경의 로컬 시간대를 따르기 때문)

### TO-BE
- UTC offset을 고려하지 않고, 서울의 시간 기준으로 맞추어 년월일을 추출하기 위해 `toLocaleDateString`을 사용함
- `PostList`의 경우, 작성일자에서 년도 값만을 추출하기 위해 시분초 이하를 `split`으로 분리하고 년월일만 가져오도록 수정함